### PR TITLE
JSON formatting for Twitch message data

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -10,17 +10,17 @@ import (
 const maxMessageLength = 510
 
 type ircMessage struct {
-	Raw     string
-	Tags    map[string]string
-	Source  ircMessageSource
-	Command string
-	Params  []string
+	Raw     string            `json:"raw"`
+	Tags    map[string]string `json:"tags"`
+	Source  ircMessageSource  `json:"source"`
+	Command string            `json:"command"`
+	Params  []string          `json:"params"`
 }
 
 type ircMessageSource struct {
-	Nickname string
-	Username string
-	Host     string
+	Nickname string `json:"nickname"`
+	Username string `json:"username"`
+	Host     string `json:"host"`
 }
 
 func parseIRCMessage(line string) (*ircMessage, error) {

--- a/message.go
+++ b/message.go
@@ -52,8 +52,8 @@ const (
 )
 
 type messageTypeDescription struct {
-	Type   MessageType
-	Parser func(*ircMessage) Message
+	Type   MessageType               `json:"type"`
+	Parser func(*ircMessage) Message `json:"parser"`
 }
 
 var messageTypeMap map[string]messageTypeDescription
@@ -80,16 +80,16 @@ func init() {
 
 // EmotePosition is a single position of an emote to be used for text replacement.
 type EmotePosition struct {
-	Start int
-	End   int
+	Start int `json:"start"`
+	End   int `json:"end"`
 }
 
 // Emote twitch emotes
 type Emote struct {
-	Name      string
-	ID        string
-	Count     int
-	Positions []EmotePosition
+	Name      string          `json:"name"`
+	ID        string          `json:"id"`
+	Count     int             `json:"count"`
+	Positions []EmotePosition `json:"positions"`
 }
 
 // ParseMessage parse a raw Twitch IRC message


### PR DESCRIPTION
Run easytags on irc.go, message.go to format twitch IRC message contents (e.g. emotes, etc.)

This adds some missing JSON tags.